### PR TITLE
adding support for time and timezone

### DIFF
--- a/create_assignments_from_csv_readme.md
+++ b/create_assignments_from_csv_readme.md
@@ -1,17 +1,20 @@
 ## Create Assignments From CSV
 
 This script reads a CSV file containing the required fields to add unassigned assignments to a workforce project. Attachments can also be uploaded if the path to the file is specified in the CSV file.
-
-Supports Python 2.7+, 3.4+
+This script supports time (hours and minute) and timezone offset. When loading data to ArcGIS Online hosted feature layer, time info is supposed to be in UTC (because date and time are stored in UTC).
+The script will convert data from csv file to UTC time zone so you don't have to worry about any offset between uploaded data and requested data form the workforce client app (web or mobile).
+For that the script uses a third party library : arrow (https://github.com/crsmithdev/arrow).
+This lib has to be installed before using the script (pip install arrow).
+Supports Python 3.4+
 
 ----
 
 Consider the following CSV example table that is to be imported into Workforce:
 
-| xField  | yField | Type | Location         | Dispatcher | Description      | Priority | Work Order Id | Due Date  | Attachment                           |
-|---------|--------|------|------------------|------------|------------------|----------|---------------|-----------|--------------------------------------|
-| -118.15 | 33.8   | 1    | 123 Street # 765 | 1          | Test Description | 4        | 1             | 4/28/2016 | ../sample_data/attachments/logo1.png |
-| -118.37 | 34.086 | 2    | 124 Street # 765 | 2          | Test Description | 3        | 2             | 4/29/2016 |                                      |
+| xField  | yField | Type | Location         | Dispatcher | Description      | Priority | Work Order Id | Due Date              | Attachment                           |
+|---------|--------|------|------------------|------------|------------------|----------|---------------|-----------------------|--------------------------------------|
+| -118.15 | 33.8   | 1    | 123 Street # 765 | 1          | Test Description | 4        | 1             | 4/28/2016 17:30 -0400 | ../sample_data/attachments/logo1.png |
+| -118.37 | 34.086 | 2    | 124 Street # 765 | 2          | Test Description | 3        | 2             | 4/29/2016 18:30 -0400 |                                      |
 
 
 Due to the various naming conventions organizations may have, this script has many options allowing the user to specify the names of each column as well as the date format. In addition to the authentication arguments, the script specific arguments are as follows:
@@ -29,12 +32,12 @@ Due to the various naming conventions organizations may have, this script has ma
 - -workOrderIdField \<workOrderIdField\> - The name of the field in the CSV file that contains the workerOrderId (Optional)
 - -dueDateField \<dueDateField\> - The name of the field in the CSV file that contains the dueDate (Optional)
 - -attachmentFileField \<attachmentFileField\> - The name of the CSV file that contains the file (if any) to upload with the assignmnent (Optional)
-- -dateFormat \<dateFormat\> - The date format to use (Optional - defaults to "%m/%d/%Y")
+- -dateFormat \<dateFormat\> - The date format to use (Optional - defaults to "%m/%d/%Y %H:%M %z")
 - -wkid \<wkid\> - The spatial reference wkid that the x and y fields are in (Optional - defaults to 4236 (GCS_WGS_1984))
 
 Example Usage:
 ```python
-python create_assignments_from_csv.py -csvFile "../sample_data/assignments.csv" -u username -p password -url "https://<org>.maps.arcgis.com" -pid "038a1926d2d741dc8acabefd5b2cc5d3" -xField "xField" -yField "yField" -assignmentTypeField "Type" -locationField "Location" -descriptionField "Description" -priorityField "Priority" -workOrderIdField "Work Order Id" -dueDateField "Due Date" -attachmentFileField "Attachment" -wkid 102100 -logFile "../log.txt"
+python create_assignments_from_csv.py -csvFile "../sample_data/assignments.csv" -u username -p password -url "https://<org>.maps.arcgis.com" -pid "038a1926d2d741dc8acabefd5b2cc5d3" -xField "xField" -yField "yField" -assignmentTypeField "Type" -locationField "Location" -descriptionField "Description" -priorityField "Priority" -workOrderIdField "Work Order Id" -dueDateField "Due Date" -attachmentFileField "Attachment" -dateFormat "%%d/%%m/%%Y %%H:%%M %%z" -wkid 102100 -logFile "../log.txt"
 ```
 
 ## What it does

--- a/standalone_scripts/create_assignments_from_csv.py
+++ b/standalone_scripts/create_assignments_from_csv.py
@@ -33,11 +33,12 @@ import mimetypes
 import os
 import traceback
 import workforcehelpers
+import arrow
 
 
 def get_assignments_from_csv(csvFile, xField, yField, assignmentTypeField, locationField, dispatcherIdField=None,
                              descriptionField=None, priorityField=None, workOrderIdField=None, dueDateField=None,
-                             dateFormat=r"%m/%d/%Y", wkid=102100, attachmentFileField=None):
+                             dateFormat=r"%m/%d/%Y %H:%M", wkid=102100, attachmentFileField=None):
     """
     Creates a list of dictionary objects representing assignments
     :param csvFile: The CSV file to read
@@ -50,7 +51,7 @@ def get_assignments_from_csv(csvFile, xField, yField, assignmentTypeField, locat
     :param priorityField: The name of the field containing the priority
     :param workOrderIdField: The name of the filed containing the workOrderId
     :param dueDateField: The name of the field containing the dueDate
-    :param dateFormat: The format that the dueDate is in (defaults to %m/%d/%Y)
+    :param dateFormat: The format that the dueDate is in (defaults to %m/%d/%Y %H:%M)
     :param wkid: The wkid that the x,y values use (defaults to 102100 which matches assignments FS)
     :param attachmentFileField: The attachment file field to use
     :return: A list of dictionary objects representing assignments
@@ -79,9 +80,9 @@ def get_assignments_from_csv(csvFile, xField, yField, assignmentTypeField, locat
         if descriptionField: new_assignment["data"]["attributes"]["description"] = assignment[descriptionField]
         if priorityField: new_assignment["data"]["attributes"]["priority"] = int(assignment[priorityField])
         if workOrderIdField: new_assignment["data"]["attributes"]["workOrderId"] = int(assignment[workOrderIdField])
-        if dueDateField: new_assignment["data"]["attributes"]["dueDate"] = datetime.datetime.strptime(
+        if dueDateField: new_assignment["data"]["attributes"]["dueDate"] = arrow.Arrow.strptime(
             assignment[dueDateField],
-            dateFormat).strftime("%m/%d/%Y")
+            dateFormat).to('utc').strftime("%m/%d/%Y %H:%M")
         if attachmentFileField: new_assignment["attachmentFile"] = \
             assignment[attachmentFileField].strip().rstrip()
         assignments_out.append(new_assignment)
@@ -277,8 +278,8 @@ if __name__ == "__main__":
     parser.add_argument('-dueDateField', dest='dueDateField', help="The field that contains the dispatcherId")
     parser.add_argument('-attachmentFileField', dest='attachmentFileField',
                         help="The field that contains the file path to the attachment to upload")
-    parser.add_argument('-dateFormat', dest='dateFormat', default=r"%m/%d/%Y",
-                        help="The format to use for the date (eg. '%m/%d/%Y'")
+    parser.add_argument('-dateFormat', dest='dateFormat', default=r"%m/%d/%Y %H:%M",
+                        help="The format to use for the date (eg. '%m/%d/%Y %H:%M'")
     parser.add_argument('-csvFile', dest='csvFile', help="The path/name of the csv file to read")
     parser.add_argument('-wkid', dest='wkid', help='The wkid that the x,y values are use', type=int, default=4326)
     parser.add_argument('-logFile', dest='logFile', help='The log file to use', required=True)


### PR DESCRIPTION
Adding support for time and timezone offset when loading data from csv file.
Date and time are stored in UTC on ArcGIS Online. So the script supports time and time zone offset. It converts time to UTC according to offset specified in csv file for each record.